### PR TITLE
Add Psalm-Integration

### DIFF
--- a/src/Discolight.php
+++ b/src/Discolight.php
@@ -81,7 +81,14 @@ final class Discolight implements ContainerInterface
         foreach ($ref->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             if ($returnType = $method->getReturnType()) {
                 if (! $returnType->isBuiltin()) {
-                    $returnTypeName = $method->getReturnType()->getName();
+                    $returnType = $method->getReturnType();
+                    if (null === $returnType) {
+                        throw new \RuntimeException(\sprintf(
+                            'The returnType of function %s is weird and breaks our system...',
+                            $method->getName()
+                        ));
+                    }
+                    $returnTypeName = $returnType->getName();
 
                     if (\array_key_exists($returnTypeName, $serviceFactoryMap)) {
                         throw new \RuntimeException(\sprintf(

--- a/src/ServiceRegistry.php
+++ b/src/ServiceRegistry.php
@@ -18,6 +18,12 @@ trait ServiceRegistry
      */
     private $serviceRegistry = [];
 
+    /**
+     * @template T
+     * @psalm-param class-string $serviceId
+     * @psalm-param callable():T $factory
+     * @return T
+     */
     private function makeSingleton(string $serviceId, callable $factory)
     {
         if (! isset($this->serviceRegistry[$serviceId])) {


### PR DESCRIPTION
This adds a DocBlock to allow psalm to infer the correct return type of the `makeSingleton`-function by using the return type of the callback as return tyoe of the function.

Using the `$serviceId` does not work as that might be an interface and the Implementation will allways return a less sppecific instance and therefore cause other issues 