### PR TITLE
[WIP] Add PHP 8 support and configuration by attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
   ],
   "require": {
     "php": "^7.2 | ^8.0",
-    "roave/security-advisories": "dev-master",
-    "psr/container": "^1.0"
+    "psr/container": "^1.0 | ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
     "satooshi/php-coveralls": "^1.0",
-    "malukenho/docheader": "^0.1.4"
+    "malukenho/docheader": "^0.1.4",
+    "roave/security-advisories": "dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,12 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 | ^8.0",
     "roave/security-advisories": "dev-master",
     "psr/container": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0",
-    "prooph/php-cs-fixer-config": "^0.3",
+    "phpunit/phpunit": "^8.0",
     "satooshi/php-coveralls": "^1.0",
     "malukenho/docheader": "^0.1.4"
   },

--- a/src/Discolight.php
+++ b/src/Discolight.php
@@ -55,7 +55,7 @@ final class Discolight implements ContainerInterface
     /**
      * {@inheritdoc}
      */
-    public function has($id)
+    public function has($id): bool
     {
         $id = $this->aliasMap[$id] ?? $id;
 

--- a/src/ServiceDefinition.php
+++ b/src/ServiceDefinition.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of event-engine/discolight.
+ * (c) 2018-2020 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace EventEngine\Discolight;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class ServiceDefinition
+{
+    public $serviceId;
+    public function __construct(string $serviceId)
+    {
+        $this->serviceId = $serviceId;
+    }
+}

--- a/src/ServiceRegistry.php
+++ b/src/ServiceRegistry.php
@@ -20,9 +20,14 @@ trait ServiceRegistry
 
     /**
      * @template T
-     * @psalm-param class-string $serviceId
+     *
+     * @psalm-param class-string<T> $serviceId
      * @psalm-param callable():T $factory
-     * @return T
+     * @psalm-return T
+     *
+     * @param string $serviceId
+     * @param callable $factory
+     * @return object
      */
     private function makeSingleton(string $serviceId, callable $factory)
     {


### PR DESCRIPTION
Re #2 

This adds support for the following:

- PHP 8
- Configure service definition by attribute (`EventEngine\Discolight\ServiceDefinition`).
- Register multiples instances of the same type (but f.e. with a different factory method).
- Register instances under more than 1 service id. This needs a second though because it behaves like aliases. It was inferred based on 1) attributes can be added more than once 2) PHP 8 (return) union types.
- Register instances with a builtin return type (like `callable`)

Above list is available for PHP 8 only but doesn't break applications running PHP 7.

Example 1:

```php
use EventEngine\Discolight\ServiceDefinition;
use Mezzio\Authentication\UserInterface;
use Mezzio\Authentication\DefaultUser;

final class ServiceFactory
{
    #[ServiceDefinition('Mezzio\Authentication\UserInterface')]
    public function userFactory(): callable
    {
        return $this->makeSingleton(UserInterface::class, function () {
            return function (string $identity, array $roles = [], array $details = []): UserInterface {
                Assert::allString($roles);
                Assert::isMap($details);

                return new DefaultUser($identity, $roles, $details);
            };
        });
    }
}

$serviceFactory = new ServiceFactory();
$container = new Discolight($serviceFactory);
$serviceFactory->setContainer($container);

$userFactory = $container->get(Mezzio\Authentication\UserInterface::class);
```

Example 2:

```php
use EventEngine\Discolight\ServiceDefinition;
use Mezzio\Authentication\AuthenticationInterface;
use Mezzio\Authentication\UserInterface;

final class ServiceFactory
{
    #[ServiceDefinition('middleware.basic-auth')]
    public function basicAuthenticationMiddleware(): AuthenticationMiddleware
    {
        return $this->makeSingleton('middleware.basic-auth', function () {
            return new AuthenticationMiddleware($this->basicAuthenticationAdapter());
        });
    }

    #[ServiceDefinition('middleware.jwt-auth')]
    public function jwtAuthenticationMiddleware(): AuthenticationMiddleware
    {
        return $this->makeSingleton('middleware.jwt-auth', function () {
            return new AuthenticationMiddleware($this->jwtAuthenticationAdapter());
        });
    }
    
    protected function basicAuthenticationAdapter(): AuthenticationInterface
    {
        // return authentication adapter
    }
    
    protected function jwtAuthenticationAdapter(): AuthenticationInterface
    {
        // return authentication adapter
    }
}

$serviceFactory = new ServiceFactory();
$container = new Discolight($serviceFactory);
$serviceFactory->setContainer($container);

$basicAuthMiddleware = $container->get('middleware.basic-auth');
$jwtAuthMiddleware = $container->get('middleware.jwt-auth');
```

Fixed some unreachable code as well. The null check in the following code can not happen:

```php
if ($returnType = $method->getReturnType()) {
    if (! $returnType->isBuiltin()) {
        $returnType = $method->getReturnType();
        if (null === $returnType) {
            throw new \RuntimeException(\sprintf(
                'The returnType of function %s is weird and breaks our system...',
                $method->getName()
            ));
         }
```

**Oh, and I've removed the prooph/php-cs-fixer-config dependency for now, since it's [not PHP 8 ready yet](https://github.com/prooph/php-cs-fixer-config/pull/8).**